### PR TITLE
Support graceful timeout option on ConsumeQueueCommand (#9394)

### DIFF
--- a/app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
+++ b/app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
@@ -43,7 +43,15 @@ class ConsumeQueueCommand extends ContainerAwareCommand
                 InputOption::VALUE_OPTIONAL,
                 'Number of messages from the queue to process. Default is infinite',
                 null
+            )
+            ->addOption(
+                '--timeout',
+                '-t',
+                InputOption::VALUE_REQUIRED,
+                'Set a graceful execution time at this many seconds in the future.',
+                null
             );
+
         parent::configure();
     }
 
@@ -76,7 +84,14 @@ class ConsumeQueueCommand extends ContainerAwareCommand
             return 0;
         }
 
-        $queueService->consumeFromQueue($queueName, $messages);
+        $timeout = $input->getOption('timeout');
+        if (0 > $timeout) {
+            $output->writeLn('You did not provide a valid number of seconds. It should be null or greater than 0');
+
+            return 0;
+        }
+
+        $queueService->consumeFromQueue($queueName, $messages, $timeout);
 
         return 0;
     }

--- a/app/bundles/QueueBundle/Event/QueueEvent.php
+++ b/app/bundles/QueueBundle/Event/QueueEvent.php
@@ -39,18 +39,25 @@ class QueueEvent extends CommonEvent
     private $queueName;
 
     /**
+     * @var int|null
+     */
+    private $timeout;
+
+    /**
      * QueueEvent constructor.
      *
      * @param string   $protocol
      * @param string   $queueName
      * @param int|null $messages
+     * @param int|null $timeout
      */
-    public function __construct($protocol, $queueName, array $payload = [], $messages = null)
+    public function __construct($protocol, $queueName, array $payload = [], $messages = null, $timeout = null)
     {
         $this->messages  = $messages;
         $this->payload   = $payload;
         $this->protocol  = $protocol;
         $this->queueName = $queueName;
+        $this->timeout   = $timeout;
     }
 
     /**
@@ -83,6 +90,14 @@ class QueueEvent extends CommonEvent
     public function getQueueName()
     {
         return $this->queueName;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
     }
 
     /**

--- a/app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
+++ b/app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
@@ -60,6 +60,12 @@ class RabbitMqSubscriber extends AbstractQueueSubscriber
             'durable'     => true,
         ]);
         $consumer->setRoutingKey($event->getQueueName());
+
+        // Check event for positive execution time and set on Consumer
+        if (0 < ($timeout = $event->getTimeout())) {
+            $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture($timeout);
+        }
+
         $consumer->consume($event->getMessages());
     }
 }

--- a/app/bundles/QueueBundle/Queue/QueueService.php
+++ b/app/bundles/QueueBundle/Queue/QueueService.php
@@ -72,11 +72,12 @@ class QueueService
     /**
      * @param string   $queueName
      * @param int|null $messages
+     * @param int|null $timeout
      */
-    public function consumeFromQueue($queueName, $messages = null)
+    public function consumeFromQueue($queueName, $messages = null, $timeout = null)
     {
         $protocol = $this->coreParametersHelper->get('queue_protocol');
-        $event    = new QueueEvent($protocol, $queueName, [], $messages);
+        $event    = new QueueEvent($protocol, $queueName, [], $messages, $timeout);
         $this->eventDispatcher->dispatch(QueueEvents::CONSUME_MESSAGE, $event);
     }
 


### PR DESCRIPTION
Added an option (--timeout=TIMEOUT, -t TIMEOUT) takes a number of
seconds to be used as the graceful execution time on the Queue
Consumer.

The value is then passed as an argument to the Queue Service's
consumeFromQueue method, where it is passed as a constructor argument
for the QueueEvent to be dispatched. Then, the RabbitMqSubscriber uses
the event's timeout property to maybe call the consumer's
setGracefulMaxExecutionDateTimeFromSecondsInTheFuture method before
calling $consumer->consume(...).

This will limit the execution time of the ConsumeQueueCommand by
allowing it to exit gracefully after TIMEOUT seconds have elapsed.

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for features or enhancements / 3.2 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
