### PR TITLE
Update .gitpod.Dockerfile to bump DDEV version

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,4 +8,4 @@ RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
 
 # Update package information and install DDEV
-RUN sudo apt update && sudo apt install -y ddev=1.21.6
+RUN sudo apt update && sudo apt install -y ddev=1.23.3


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:
DDEV is currently failing to start on Gitpod, as we have an outdated version.

![screenshot-mautic-mautic-ixsuuxr1t5v ws-eu115 gitpod io-2024 07 12-17_39_39](https://github.com/user-attachments/assets/3f2a474d-0f93-486f-bcb5-ef1f7ed612f7)

This PR bumps the docker file used by Gitpod to the latest version.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make sure it works. If the web/db containers timeout, you might need to issue the `ddev restart` command (sometimes happens on first load)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
